### PR TITLE
Ensure v13 compatibility

### DIFF
--- a/.github/upcoming/26.md
+++ b/.github/upcoming/26.md
@@ -3,4 +3,5 @@
 #### Refactor
 
 - Add `@extensionScannerIgnoreLine` to any false positives thrown up from the extension file scanner (#26)
-- Replace `StandaloneView` with `ViewFactoryInterface.` (#26)
+- Replace `StandaloneView` with `ViewFactoryInterface` (#26)
+- Remove deprecated constants (#26)

--- a/.github/upcoming/26.md
+++ b/.github/upcoming/26.md
@@ -3,3 +3,4 @@
 #### Refactor
 
 - Add `@extensionScannerIgnoreLine` to any false positives thrown up from the extension file scanner (#26)
+- Replace `StandaloneView` with `ViewFactoryInterface.` (#26)

--- a/.github/upcoming/26.md
+++ b/.github/upcoming/26.md
@@ -1,0 +1,5 @@
+# Patch
+
+#### Refactor
+
+- Add `@extensionScannerIgnoreLine` to any false positives thrown up from the extension file scanner (#26)

--- a/Classes/Command/SetupCommand.php
+++ b/Classes/Command/SetupCommand.php
@@ -65,6 +65,7 @@ class SetupCommand extends Command
 			$this->singlePageUid = $this->getSinglePageUid();
 			$this->modelName = $this->getModelName($this->tcaName);
 		} catch (InvalidSetupValueException $e) {
+			// @extensionScannerIgnoreLine
 			$this->io->error($e->getMessage());
 			return Command::FAILURE;
 		}
@@ -194,6 +195,7 @@ class SetupCommand extends Command
 		if ($success) {
 			$this->io->success('RouteEnhancer configuration created');
 		} else {
+			// @extensionScannerIgnoreLine
 			$this->io->error('There was a problem creating the RouteEnhancer configuration');
 		}
 
@@ -271,6 +273,7 @@ class SetupCommand extends Command
 		if ($success) {
 			$this->io->success('Sitemap configuration created');
 		} else {
+			// @extensionScannerIgnoreLine
 			$this->io->error('There was a problem creating the Sitemap configuration');
 		}
 
@@ -327,6 +330,7 @@ class SetupCommand extends Command
 		if ($success) {
 			$this->io->success('LinkHandler TSConfig created');
 		} else {
+			// @extensionScannerIgnoreLine
 			$this->io->error('There was a problem creating the LinkHandler TSConfig');
 		}
 
@@ -388,6 +392,7 @@ class SetupCommand extends Command
 		if ($success) {
 			$this->io->success('LinkHandler TypoScript created');
 		} else {
+			// @extensionScannerIgnoreLine
 			$this->io->error('There was a problem creating the LinkHandler TypoScript');
 		}
 

--- a/Classes/Controller/AnthologyController.php
+++ b/Classes/Controller/AnthologyController.php
@@ -304,6 +304,7 @@ class AnthologyController extends ActionController
 		$this->settings['tca'] = $this->repositoryFactory->getTcaName($this->settings['repository']);
 
 		foreach ($filters as $filter) {
+			// @extensionScannerIgnoreLine
 			$filter->setOptions($this->filterFactory->getFilters()[$filter->filterType]::getOptions($filter, $this->settings));
 			$filter->setParameter($activeFilters[$filter->getUid()] ?? null);
 		}
@@ -317,6 +318,7 @@ class AnthologyController extends ActionController
 			? array_filter($this->request->getArgument('filter'))
 			: [];
 
+		// @extensionScannerIgnoreLine
 		unset($activeFilters['init']);
 
 		return count($activeFilters) ? $activeFilters : null;

--- a/Classes/EventListener/PreviewRenderingEventListener.php
+++ b/Classes/EventListener/PreviewRenderingEventListener.php
@@ -7,7 +7,8 @@ namespace LiquidLight\Anthology\EventListener;
 use LiquidLight\Anthology\Backend\AnthologyPreviewRenderer;
 use TYPO3\CMS\Backend\View\Event\PageContentPreviewRenderingEvent;
 use TYPO3\CMS\Core\Attribute\AsEventListener;
-use TYPO3\CMS\Fluid\View\StandaloneView;
+use TYPO3\CMS\Core\View\ViewFactoryData;
+use TYPO3\CMS\Core\View\ViewFactoryInterface;
 
 #[AsEventListener(
 	identifier: 'llanthology/after-tca-compilation-event-listener',
@@ -21,7 +22,7 @@ class PreviewRenderingEventListener
 
 	public function __construct(
 		protected readonly AnthologyPreviewRenderer $anthologyPreviewRenderer,
-		protected readonly StandaloneView $backendPreview
+		protected readonly ViewFactoryInterface $viewFactory
 	) {
 	}
 
@@ -35,14 +36,19 @@ class PreviewRenderingEventListener
 			return;
 		}
 
-		$this->backendPreview->setTemplatePathAndFilename(static::BACKEND_PREVIEW_PATH);
-		$this->backendPreview->assignMultiple([
+		$viewFactoryData = new ViewFactoryData(
+			templatePathAndFilename: static::BACKEND_PREVIEW_PATH,
+			request: $event->getPageLayoutContext()->getCurrentRequest(),
+		);
+
+		$view = $this->viewFactory->create($viewFactoryData);
+		$view->assignMultiple([
 			'settings' => $this->anthologyPreviewRenderer->getPluginSettings($event->getRecord()),
 			'model' => $this->anthologyPreviewRenderer->getModelData($event->getRecord()),
 			'sources' => $this->anthologyPreviewRenderer->getSources($event->getRecord()),
 			'correspondingPage' => $this->anthologyPreviewRenderer->getCorrespondingPage($event->getRecord()),
 		]);
 
-		$event->setPreviewContent($this->backendPreview->render());
+		$event->setPreviewContent($view->render());
 	}
 }

--- a/Tests/Unit/Domain/Model/FilterTest.php
+++ b/Tests/Unit/Domain/Model/FilterTest.php
@@ -69,6 +69,7 @@ class FilterTest extends TestCase
 	 */
 	public function testGetOptionsReturnsInitialValueForOptions(): void
 	{
+		// @extensionScannerIgnoreLine
 		self::assertSame([], $this->subject->getOptions());
 	}
 
@@ -82,8 +83,10 @@ class FilterTest extends TestCase
 			['value' => '1', 'title' => 'Option 1'],
 			['value' => '2', 'title' => 'Option 2'],
 		];
+		// @extensionScannerIgnoreLine
 		$this->subject->setOptions($options);
 
+		// @extensionScannerIgnoreLine
 		self::assertSame($options, $this->subject->getOptions());
 	}
 
@@ -95,7 +98,10 @@ class FilterTest extends TestCase
 
 	public function testHasPublicTitleProperty(): void
 	{
+		// @extensionScannerIgnoreLine
 		$this->subject->title = 'Test Filter';
+
+		// @extensionScannerIgnoreLine
 		self::assertSame('Test Filter', $this->subject->title);
 	}
 

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -4,11 +4,6 @@ declare(strict_types=1);
 
 // Bootstrap file for ll_anthology PHPUnit tests
 
-// Define TYPO3 constants for testing
-if (!defined('TYPO3_MODE')) {
-	define('TYPO3_MODE', 'BE');
-}
-
 if (!defined('TYPO3')) {
 	define('TYPO3', true);
 }
@@ -26,16 +21,6 @@ if (file_exists($autoloadFile)) {
 }
 
 
-// Set up minimal TYPO3 environment for testing
-if (!defined('PATH_site')) {
-	define('PATH_site', __DIR__ . '/../.Build/public/');
-}
-
-if (!defined('TYPO3_PATH_WEB')) {
-	define('TYPO3_PATH_WEB', PATH_site);
-}
-
-// Skip TYPO3 Environment initialization for now - too complex for unit tests
 
 // Set up minimal TCA configuration for testing
 global $TCA;


### PR DESCRIPTION
The TYPO3 Extension files scanner found several false positives but also identified a depreciated class use (`StandaloneView`) as well as a constant removed in v10

- Added `@extensionScannerIgnoreLine` to prevent false positives
- Converted `StandaloneView` to use `ViewFactoryInterface`
- Removed deprecated constant

Also identified an issue with plugin registration which needs to be addressed seperately - see #27 