### PR TITLE
Migrate plugin to CType

### DIFF
--- a/.github/upcoming/27.md
+++ b/.github/upcoming/27.md
@@ -1,0 +1,5 @@
+# Major
+
+#### Feature
+
+- [BREAKING] Migrate plugin from list_type to CType (#27)

--- a/Classes/EventListener/PreviewRenderingEventListener.php
+++ b/Classes/EventListener/PreviewRenderingEventListener.php
@@ -30,8 +30,7 @@ class PreviewRenderingEventListener
 	{
 		if (
 			$event->getTable() !== 'tt_content'
-			|| $event->getRecordType() !== 'list' ||
-			($event->getRecord()['list_type'] ?? false) !== static::PLUGIN_SIGNATURE
+			|| $event->getRecordType() !== static::PLUGIN_SIGNATURE
 		) {
 			return;
 		}

--- a/Classes/Hook/FilterConfigurationHook.php
+++ b/Classes/Hook/FilterConfigurationHook.php
@@ -128,7 +128,7 @@ class FilterConfigurationHook
 				 * use a compatible naming format for the plugin or this will not
 				 * display any available filter fields
 				 */
-				$queryBuilder->expr()->like('list_type', $queryBuilder->createNamedParameter('llanthology%_%view')),
+				$queryBuilder->expr()->like('CType', $queryBuilder->createNamedParameter('llanthology%_%view')),
 				$queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter($params['effectivePid'], Connection::PARAM_INT)),
 				"FIND_IN_SET(" . $queryBuilder->createNamedParameter($params['row']['uid'], Connection::PARAM_INT) . ", EXTRACTVALUE(`pi_flexform`, '//field[@index=\'settings.filters\']/value'))"
 			)

--- a/Classes/Updates/AnthologyListTypeToCTypeUpdate.php
+++ b/Classes/Updates/AnthologyListTypeToCTypeUpdate.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiquidLight\Anthology\Updates;
+
+use TYPO3\CMS\Install\Attribute\UpgradeWizard;
+use TYPO3\CMS\Install\Updates\AbstractListTypeToCTypeUpdate;
+
+#[UpgradeWizard('anthologyListTypeToCTypeUpdate')]
+final class AnthologyListTypeToCTypeUpdate extends AbstractListTypeToCTypeUpdate
+{
+	public function getTitle(): string
+	{
+		return 'Migrate Anthology plugins to content elements.';
+	}
+
+	public function getDescription(): string
+	{
+		return 'The Anthology plugin is now registered as a content element. Updates existing records and backend user permissions.';
+	}
+
+	protected function getListTypeToCTypeMapping(): array
+	{
+		return [
+			'llanthology_anthologyview' => 'llanthology_anthologyview',
+		];
+	}
+}

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -18,15 +18,24 @@ call_user_func(function () {
 		'LLL:EXT:ll_anthology/Resources/Private/Language/locallang.xlf:description'
 	);
 
-	// Add FlexForm to the plugin
 	$pluginSignature = 'llanthology_anthologyview';
 
-	// Add pi_flexform to the plugin
-	$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist'][$pluginSignature] = 'pi_flexform';
+	// Add pi_flexform & other fields to the plugin
+	ExtensionManagementUtility::addToAllTCAtypes(
+		'tt_content',
+		'--div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.plugin,
+			pi_flexform,
+			pages,
+			recursive,
+		',
+		$pluginSignature,
+		'after:header',
+	);
 
 	// Add the FlexForm configuration
 	ExtensionManagementUtility::addPiFlexFormValue(
+		'*',
+		'FILE:EXT:ll_anthology/Configuration/FlexForms/ViewPlugin.xml',
 		$pluginSignature,
-		'FILE:EXT:ll_anthology/Configuration/FlexForms/ViewPlugin.xml'
 	);
 });

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -16,6 +16,7 @@ call_user_func(function () {
 		],
 		[
 			AnthologyController::class => 'view,list',
-		]
+		],
+		ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT
 	);
 });


### PR DESCRIPTION
Migrate the plugin from being a `list_type` definition to `CType`.

Not much code has changed but is breaking as it needs a database migration.

Resolves: #27

TYPO3 Deprecation: #105076 

Will also need doing on News and any other anthology extensions which have plugins